### PR TITLE
Added apache user and group

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,12 @@
   changed_when: false
   always_run: yes
 
+- name: Create apache user
+  user: name=apache state=present  
+
+- name: Create apache group
+  group: name=apache state=present
+
 - name: Create download directory
   file:
     path: "{{ download_dir }}"


### PR DESCRIPTION
- In the [kube_download] (https://github.com/gemini-project/ansible-role-ansible-controller/blob/master/tasks/kube_download.yml) task you assign the directories to the *apache* user and *apache* group without instantiating them