### PR TITLE
Updated the handling of downloads for the gemini_master

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of Kubernetes binaries.
-kube_version: 1.1.4
+kube_version: 1.2.0
 
 # Version of Flannel binaries.
 flannel_version: 0.5.5
@@ -23,11 +23,32 @@ ansible_temp_dir: /tmp/.ansible/files
 # Base download directory.
 download_dir: /var/www/html/releases
 
+# The URL to download Kubernetes binaries from.
+kube_release_url_base: https://storage.googleapis.com/kubernetes-release/release/v{{ kube_version }}/bin/linux/amd64/
+
+#The default url to download the flannel tar from
+flannel_release_url_base: "https://github.com/coreos/flannel/releases/download"
+flannel_release_url: "{{ flannel_release_url_base }}/v{{ flannel_version }}/flannel-{{ flannel_version }}-linux-amd64.tar.gz"
+
+#The default url to download pypy from
+pypy_release_url_base: "https://bitbucket.org/pypy/pypy/downloads"
+pypy_release_url: "{{ pypy_release_url_base }}/pypy-{{ pypy_version }}-linux64.tar.bz2"
+
+
+# List of Kubernetes binaries to download and install.
+kube_binaries:
+  - kube-apiserver
+  - kube-controller-manager
+  - kube-proxy
+  - kube-scheduler
+  - kubectl
+  - kubelet
+
 # Kubernetes base download directory.
-kube_download_dir: "{{ download_dir }}/kubernetes/{{ kube_version }}"
+kube_download_dir: "{{ download_dir }}/kubernetes/v{{ kube_version }}"
 
 # Flannel base download directory.
-flannel_download_dir: "{{ download_dir }}/flannel/{{ flannel_version }}"
+flannel_download_dir: "{{ download_dir }}/flannel/v{{ flannel_version }}"
 
 #PyPy base download directory.
-pypy_download_dir: "{{ download_dir }}/pypy/{{ pypy_version }}"
+pypy_download_dir: "{{ download_dir }}/pypy/v{{ pypy_version }}"

--- a/tasks/flannel_download.yml
+++ b/tasks/flannel_download.yml
@@ -22,7 +22,7 @@
 
 - name: Download Flannel tar file
   get_url:
-    url: "https://github.com/coreos/flannel/releases/download/v{{ flannel_version }}/flannel-{{ flannel_version }}-linux-amd64.tar.gz"
+    url: "{{ flannel_release_url }}"  
     dest: "{{ flannel_download_dir }}"
     validate_certs: False
   environment:

--- a/tasks/kube_download.yml
+++ b/tasks/kube_download.yml
@@ -1,10 +1,4 @@
 ---
-- name: Determine if Kubernetes download directory exists
-  stat: path={{ kube_download_dir }}
-  register: kdd
-  changed_when: false
-  always_run: yes
-
 - name: Create Kubernetes download directory
   file:
     path: "{{ kube_download_dir }}"
@@ -12,29 +6,26 @@
     owner: apache
     group: apache
     mode: '0701'
-  when: not kdd.stat.exists
 
-- name: Determine if Kubernetes tar file exists
-  stat: path={{ kube_download_dir }}/kubernetes.tar.gz
-  register: kt
-  changed_when: false
-  always_run: yes
-
-- name: Download Kubernetes tar file
+- name: Download Kubernetes binaries
   get_url:
-    url: "https://github.com/kubernetes/kubernetes/releases/download/v{{ kube_version }}/kubernetes.tar.gz"
-    dest: "{{ kube_download_dir }}"
+    url: "{{ kube_release_url_base }}{{ item }}"
+    dest: "{{ kube_download_dir }}/{{ item }}"
+    mode: 0755
     validate_certs: False
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
     no_proxy: "{{ no_proxy|default('') }}"
-  when: not kt.stat.exists
+  with_items:
+    - "{{ kube_binaries }}"
 
-- name: Set Flannel tar file permissions
+- name: Set Kubernetes binaries permissions
   file:
-    path: "{{ kube_download_dir }}/kubernetes.tar.gz"
+    path: "{{ kube_download_dir }}/{{ item }}"
     state: file
     owner: apache
     group: apache
     mode: '0701'
+  with_items: 
+    - "{{ kube_binaries }}"

--- a/tasks/pypy_download.yml
+++ b/tasks/pypy_download.yml
@@ -17,7 +17,7 @@
 
 - name: Download PyPy tar file
   get_url:
-    url: "https://bitbucket.org/pypy/pypy/downloads/pypy-{{ pypy_version }}-linux64.tar.bz2"
+    url: "{{ pypy_release_url }}"
     dest: "{{ pypy_download_dir }}"
     validate_certs: False
   environment:


### PR DESCRIPTION
- Kube 1.20
- Kube binaries, not tar
- Made the urls for pypy and flannel variables