### PR TITLE
Removes Apache Permissions and Creates an http dependency

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,7 @@
+# roles/ansible-controller/handlers/main.yml
+---
+
+- name: restart httpd
+  service:
+    name: httpd
+    state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+    - { role: httpd }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,15 +12,6 @@
   - net-tools
   tags: ansible-controller
 
-- name: Create Ansible temp directory
-  file: path={{ ansible_temp_dir }} state=directory
-
-- name: Create apache user
-  user: name=apache state=present  
-
-- name: Create apache group
-  group: name=apache state=present
-
 - name: Create download directory
   file:
     path: "{{ download_dir }}"
@@ -28,6 +19,7 @@
     owner: apache
     group: apache
     mode: '0701'
+  notify: restart httpd
 
 - include: flannel_download.yml
   when: manage_flannel_download


### PR DESCRIPTION
Previously, the releases dir had broken selinux lables. This
commit creates a dependncy on the https role, so the releases dir
is created afterwards and restarts the httpd service. Also removes
http permission mgt since that should be done by the httpd role.